### PR TITLE
Set up xhermes and its dependencies as spack packages.

### DIFF
--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -14,7 +14,7 @@ class Hermes3(CMakePackage):
     coordinates."""
 
     homepage = "https://hermes3.readthedocs.io/"
-    url = "https://github.com/bendudson/hermes-3/archive/refs/tags/v1.1.0.tar.gz"
+    # url = "https://github.com/bendudson/hermes-3/archive/refs/tags/v1.1.0.tar.gz"
     git = "https://github.com/bendudson/hermes-3.git"
 
     maintainers("bendudson")
@@ -24,12 +24,10 @@ class Hermes3(CMakePackage):
     # A 'working' version for use with the develop option in spack envs
     version("working", branch="master")
 
-    # Note: Release tarballs don't include BOUT++ submodule
-    #       so for releases specify the commit hash
-    version("master", branch="master")
-    version("1.3.0", commit="5be1525")
-    version("1.2.1", commit="f1dadcc")
-    version("1.2.0", commit="081c8cf")
+    version("master", branch="master", submodules=True, preferred=True)
+    version("1.3.0", tag="v1.3.0", submodules=True)
+    version("1.2.1", tag="v1.2.1", submodules=True)
+    version("1.2.0", tag="v1.2.0", submodules=True)
 
     variant(
         "limiter",

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -25,6 +25,7 @@ class Hermes3(CMakePackage):
     version("working", branch="master")
 
     version("master", branch="master", submodules=True, preferred=True)
+    version("1.3.1", tag="v1.3.1", submodules=True)
     version("1.3.0", tag="v1.3.0", submodules=True)
     version("1.2.1", tag="v1.2.1", submodules=True)
     version("1.2.0", tag="v1.2.0", submodules=True)

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -21,6 +21,9 @@ class Hermes3(CMakePackage):
 
     license("GPL-3.0-or-later")
 
+    # A 'working' version for use with the develop option in spack envs
+    version("working", branch="master")
+
     # Note: Release tarballs don't include BOUT++ submodule
     #       so for releases specify the commit hash
     version("master", branch="master")

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -59,15 +59,25 @@ class Hermes3(CMakePackage):
         "petsc+hypre+mpi~debug~fortran", when="+petsc", type=("build", "link", "run")
     )
     depends_on("py-xhermes", when="+xhermes", type=("build", "link", "run"))
+
     # Could add Sundials as a spack dependency here?
-    # Download it via the BOUT cmake flag for now
+    # Download it via the BOUT cmake flag for now (see binary_def_variants, below)
     # depends_on("sundials", when="+sundials", type=("build", "link", "run"))
 
     def cmake_args(self):
-        # Always build with Sundials.
-        # Use variants to toggle other config options.
-        return [
-            self.define("BOUT_DOWNLOAD_SUNDIALS", True),
-            self.define_from_variant("BOUT_USE_PETSC", "petsc"),
-            self.define_from_variant("HERMES_SLOPE_LIMITER", "limiter"),
+        # ON/OFF definitions controlled by variants
+        binary_def_variants = {
+            "BOUT_DOWNLOAD_SUNDIALS": "sundials",
+            "HERMES_SLOPE_LIMITER": "limiter",
+            "BOUT_USE_PETSC": "petsc",
+        }
+        variants_args = [
+            self.define_from_variant(def_str, var_str)
+            for def_str, var_str in binary_def_variants.items()
         ]
+
+        # Concatenate different arg types and return
+        args = []
+        args.extend(variants_args)
+
+        return args

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -23,6 +23,7 @@ class Hermes3(CMakePackage):
     # Note: Release tarballs don't include BOUT++ submodule
     #       so for releases specify the commit hash
     version("master", branch="master")
+    version("1.3.0", commit="5be1525")
     version("1.2.1", commit="f1dadcc")
     version("1.2.0", commit="081c8cf")
 

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import *
+from spack import *
+
 
 class Hermes3(CMakePackage):
     """A multifluid magnetized plasma simulation model.
@@ -27,19 +28,44 @@ class Hermes3(CMakePackage):
     version("1.2.1", commit="f1dadcc")
     version("1.2.0", commit="081c8cf")
 
-    variant("petsc", default=False, description="Enable PETSc solvers")
     variant(
-        "limiter", default="MC", description="Slope limiter", values=("MC", "MinMod"), multi=False
+        "limiter",
+        default="MC",
+        description="Slope limiter",
+        values=("MC", "MinMod"),
+        multi=False,
+    )
+    variant("petsc", default=False, description="Builds with PETSc support.")
+    variant("sundials", default=True, description="Builds with SUNDIALS support.")
+    variant(
+        "xhermes", default=True, description="Builds xhermes (required for some tests)."
     )
 
-    depends_on("cmake", type="build")
-    depends_on("mpi")
-    depends_on("fftw")
-    depends_on("netcdf-cxx4")
-    depends_on("petsc+hypre+mpi", when="+petsc")
+    # Always-required dependencies
+    # depends_on("adios2", type=("build", "link", "run"))
+    depends_on("cmake@3.24:", type="build")
+    depends_on("fftw", type=("build", "link", "run"))
+    depends_on("mpi", type=("build", "link", "run"))
+    depends_on("netcdf-cxx4", type=("build", "link", "run"))
+    # Should these be xhermes deps instead?
+    depends_on("py-cython", type=("build", "link", "run"))
+    depends_on("py-jinja2", type=("build", "link", "run"))
+    depends_on("py-netcdf4", type=("build", "link", "run"))
+
+    # Variant-controlled dependencies
+    depends_on(
+        "petsc+hypre+mpi~debug~fortran", when="+petsc", type=("build", "link", "run")
+    )
+    depends_on("py-xhermes", when="+xhermes", type=("build", "link", "run"))
+    # Could add Sundials as a spack dependency here?
+    # Download it via the BOUT cmake flag for now
+    # depends_on("sundials", when="+sundials", type=("build", "link", "run"))
 
     def cmake_args(self):
+        # Always build with Sundials.
+        # Use variants to toggle other config options.
         return [
             self.define("BOUT_DOWNLOAD_SUNDIALS", True),
+            self.define_from_variant("BOUT_USE_PETSC", "petsc"),
             self.define_from_variant("HERMES_SLOPE_LIMITER", "limiter"),
         ]

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -14,8 +14,7 @@ class Hermes3(CMakePackage):
     coordinates."""
 
     homepage = "https://hermes3.readthedocs.io/"
-    # url = "https://github.com/bendudson/hermes-3/archive/refs/tags/v1.1.0.tar.gz"
-    git = "https://github.com/bendudson/hermes-3.git"
+    git = "https://github.com/boutproject/hermes-3.git"
 
     maintainers("bendudson")
 

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -23,6 +23,7 @@ class Hermes3(CMakePackage):
     # Note: Release tarballs don't include BOUT++ submodule
     #       so for releases specify the commit hash
     version("master", branch="master")
+    version("1.2.1", commit="f1dadcc")
     version("1.2.0", commit="081c8cf")
 
     variant("petsc", default=False, description="Enable PETSc solvers")

--- a/packages/py-animatplot-ng/package.py
+++ b/packages/py-animatplot-ng/package.py
@@ -1,0 +1,32 @@
+from spack.package import *
+
+
+class PyAnimatplotNg(PythonPackage):
+    """A python package for making interactive as well as animated plots with matplotlib. Based on animatplot by r-makaro."""
+
+    homepage = "https://github.com/boutproject/animatplot-ng/"
+    pypi = "animatplot-ng/animatplot-ng-0.4.4.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version(
+        "0.4.4",
+        sha256="89f51ca4d63714a918f95ef14d576f420ae6f2aad08968e634379634ca375324",
+    )
+
+    # Compatible Python versions
+    depends_on("python@3.5:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools-scm@7:+toml", type="build")
+    depends_on("py-wheel@0.29:", type="build")
+
+    # Runtime dependencies
+    depends_on("py-matplotlib@2.2:", type=("build", "run"))
+
+    def config_settings(self, spec, prefix):
+        settings = {}
+        return settings

--- a/packages/py-animatplot-ng/package.py
+++ b/packages/py-animatplot-ng/package.py
@@ -2,14 +2,15 @@ from spack.package import *
 
 
 class PyAnimatplotNg(PythonPackage):
-    """A python package for making interactive as well as animated plots with matplotlib. Based on animatplot by r-makaro."""
+    """A python package for making interactive as well as animated plots with matplotlib. Based on animatplot by t-makaro."""
 
     homepage = "https://github.com/boutproject/animatplot-ng/"
     pypi = "animatplot-ng/animatplot-ng-0.4.4.tar.gz"
 
+    # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # license("UNKNOWN", checked_by="github_user1")
+    license("MIT")
 
     version(
         "0.4.4",

--- a/packages/py-boutdata/package.py
+++ b/packages/py-boutdata/package.py
@@ -1,0 +1,37 @@
+from spack.package import *
+
+
+class PyBoutdata(PythonPackage):
+    """Python tools for working with BOUT++."""
+
+    homepage = "https://github.com/boutproject/boutdata"
+    pypi = "boutdata/boutdata-0.2.1.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version(
+        "0.2.1",
+        sha256="043cddaeb38b128d2525f2005f48a5b7717ff5832a932183a4bef1d3eae389e0",
+    )
+
+    # Compatible Python versions
+    depends_on("python@3.9:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-setuptools-scm@6.2:+toml", type="build")
+
+    # Runtime dependencies
+    depends_on("py-boututils", type=("build", "run"))
+    depends_on("py-matplotlib@3.2.1:", type=("build", "run"))
+    depends_on("py-natsort@8.1.0:", type=("build", "run"))
+    depends_on("py-netcdf4", type=("build", "run"))
+    depends_on("py-numpy@1.22.0:", type=("build", "run"))
+    depends_on("py-scipy@1.4.1:", type=("build", "run"))
+    depends_on("py-sympy@1.5.1:", type=("build", "run"))
+
+    def config_settings(self, spec, prefix):
+        settings = {}
+        return settings

--- a/packages/py-boutdata/package.py
+++ b/packages/py-boutdata/package.py
@@ -7,9 +7,10 @@ class PyBoutdata(PythonPackage):
     homepage = "https://github.com/boutproject/boutdata"
     pypi = "boutdata/boutdata-0.2.1.tar.gz"
 
+    # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # license("UNKNOWN", checked_by="github_user1")
+    license("LGPL-3.0")
 
     version(
         "0.2.1",

--- a/packages/py-boututils/package.py
+++ b/packages/py-boututils/package.py
@@ -1,0 +1,34 @@
+from spack.package import *
+
+
+class PyBoututils(PythonPackage):
+    """pip-package of what was previously found in BOUT-dev/tools/pylib/boututils"""
+
+    homepage = "https://www.example.com"
+    pypi = "boututils/boututils-0.2.1.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version(
+        "0.2.1",
+        sha256="b8e12cace0638645de09647b60f1f1e0079ded359855a9d220aede94736d2fe5",
+    )
+
+    # Compatible Python versions
+    depends_on("python@3.8:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools@61:", type="build")
+    depends_on("py-setuptools-scm@6.2:+toml", type="build")
+
+    # Runtime dependencies
+    depends_on("py-matplotlib@3.2.1:", type=("build", "link", "run"))
+    depends_on("py-netcdf4", type=("build", "link", "run"))
+    depends_on("py-numpy@1.22.0:", type=("build", "link", "run"))
+    depends_on("py-scipy@1.4.1:", type=("build", "link", "run"))
+
+    def config_settings(self, spec, prefix):
+        settings = {}
+        return settings

--- a/packages/py-boututils/package.py
+++ b/packages/py-boututils/package.py
@@ -4,12 +4,13 @@ from spack.package import *
 class PyBoututils(PythonPackage):
     """pip-package of what was previously found in BOUT-dev/tools/pylib/boututils"""
 
-    homepage = "https://www.example.com"
+    homepage = "https://github.com/boutproject/boututils/"
     pypi = "boututils/boututils-0.2.1.tar.gz"
 
+    # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # license("UNKNOWN", checked_by="github_user1")
+    license("LGPL-3.0")
 
     version(
         "0.2.1",

--- a/packages/py-gelidum/package.py
+++ b/packages/py-gelidum/package.py
@@ -1,0 +1,27 @@
+from spack.package import *
+
+
+class PyGelidum(PythonPackage):
+    """Inspired by the method freeze found in other languages like Javascript, this package tries to make immutable objects to make it easier avoiding accidental modifications in your code."""
+
+    homepage = "https://github.com/diegojromerolopez/gelidum"
+    pypi = "gelidum/gelidum-0.8.2.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version(
+        "0.8.2",
+        sha256="3761191eeb11a406620bcbc853730bfa82b2b947cb55b00c57c1a94b226624bc",
+    )
+
+    # Compatible Python versions
+    depends_on("python@3.7:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools", type="build")
+
+    def config_settings(self, spec, prefix):
+        settings = {}
+        return settings

--- a/packages/py-gelidum/package.py
+++ b/packages/py-gelidum/package.py
@@ -7,9 +7,10 @@ class PyGelidum(PythonPackage):
     homepage = "https://github.com/diegojromerolopez/gelidum"
     pypi = "gelidum/gelidum-0.8.2.tar.gz"
 
+    # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # license("UNKNOWN", checked_by="github_user1")
+    license("MIT")
 
     version(
         "0.8.2",

--- a/packages/py-xbout/package.py
+++ b/packages/py-xbout/package.py
@@ -1,0 +1,64 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install py-xbout
+#
+# You can edit this file again by typing:
+#
+#     spack edit py-xbout
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyXbout(PythonPackage):
+    """xBOUT provides an interface for collecting the output data from a BOUT++ simulation into an xarray dataset in an efficient and scalable way, as well as accessor methods for common BOUT++ analysis and plotting tasks."""
+
+    homepage = "https://github.com/boutproject/xBOUT"
+    pypi = "xbout/xbout-0.3.7.tar.gz"
+
+    # maintainers("github_user1", "github_user2")
+
+    # license("UNKNOWN", checked_by="github_user1")
+
+    version(
+        "0.3.7",
+        sha256="51b6bcc888553037a623f68dccfe7755ca409801d5b2dd1b8b1ecaca78c1eff1",
+    )
+
+    # Compatible Python versions
+    depends_on("python@3.9:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools@65:", type="build")
+    depends_on("py-setuptools-scm@7:+toml", type="build")
+    depends_on("py-wheel@0.29.0:", type="build")
+
+    # Runtime dependencies
+    depends_on("py-animatplot-ng@0.4.2:", type=("build", "run"))
+    depends_on("py-boutdata@0.1.4:", type=("build", "run"))
+    depends_on("py-dask@2.10.0:+array", type=("build", "run"))
+    depends_on("py-gelidum@0.5.3:", type=("build", "run"))
+    depends_on("py-matplotlib@3.3.3:", type=("build", "run"))
+    depends_on("py-natsort@5.5.0:", type=("build", "run"))
+    depends_on("py-netcdf4@1.4.0:", type=("build", "run"))
+    depends_on("py-pillow@6.1.0:", type=("build", "run"))
+    depends_on("py-xarray@2023.01.0:", type=("build", "run"))
+
+    def config_settings(self, spec, prefix):
+        # FIXME: Add configuration settings to be passed to the build backend
+        # FIXME: If not needed, delete this function
+        settings = {}
+        return settings

--- a/packages/py-xbout/package.py
+++ b/packages/py-xbout/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install py-xbout
-#
-# You can edit this file again by typing:
-#
-#     spack edit py-xbout
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 
@@ -29,9 +12,10 @@ class PyXbout(PythonPackage):
     homepage = "https://github.com/boutproject/xBOUT"
     pypi = "xbout/xbout-0.3.7.tar.gz"
 
+    # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # license("UNKNOWN", checked_by="github_user1")
+    license("Apache-2.0")
 
     version(
         "0.3.7",

--- a/packages/py-xbout/package.py
+++ b/packages/py-xbout/package.py
@@ -58,7 +58,5 @@ class PyXbout(PythonPackage):
     depends_on("py-xarray@2023.01.0:", type=("build", "run"))
 
     def config_settings(self, spec, prefix):
-        # FIXME: Add configuration settings to be passed to the build backend
-        # FIXME: If not needed, delete this function
         settings = {}
         return settings

--- a/packages/py-xhermes/package.py
+++ b/packages/py-xhermes/package.py
@@ -1,0 +1,23 @@
+from spack import *
+
+
+class PyXhermes(PythonPackage):
+    """xhermes Python package"""
+
+    homepage = "https://github.com/boutproject/xhermes"
+    url = "https://github.com/boutproject/xhermes"
+    git = "https://github.com/boutproject/xhermes"
+
+    # maintainers = ["Mike Kryjak"]
+
+    version("main", branch="main", no_cache=True)
+
+    # Compatible Python versions
+    depends_on("python@3.6:", type=("build", "run"))
+
+    # Build dependencies
+    depends_on("py-setuptools", type="build")
+
+    # Runtime dependencies
+    depends_on("py-xbout", type=("build", "run"))
+    depends_on("py-xarray", type=("build", "run"))

--- a/packages/py-xhermes/package.py
+++ b/packages/py-xhermes/package.py
@@ -2,16 +2,18 @@ from spack import *
 
 
 class PyXhermes(PythonPackage):
-    """xhermes Python package"""
+    """xHermes is a post-processing package for Hermes-3 in 1D, 2D and 3D which provides automatic conversion to SI units and many useful plotting routines."""
 
     homepage = "https://github.com/boutproject/xhermes"
-    url = "https://github.com/boutproject/xhermes"
-    git = "https://github.com/boutproject/xhermes"
+    pypi = "xhermes/xhermes-0.1.0.tar.gz"
 
     # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    version("main", branch="main", no_cache=True)
+    version(
+        "0.1.0",
+        sha256="3aa0ba60d06cd18adfc46132f1d8deb3cd4ce69e67ee210d491bdfd7ba7871a7",
+    )
 
     # Compatible Python versions
     depends_on("python@3.6:", type=("build", "run"))

--- a/packages/py-xhermes/package.py
+++ b/packages/py-xhermes/package.py
@@ -8,7 +8,8 @@ class PyXhermes(PythonPackage):
     url = "https://github.com/boutproject/xhermes"
     git = "https://github.com/boutproject/xhermes"
 
-    # maintainers = ["Mike Kryjak"]
+    # Set a maintainer if submitting this package to the spack repo
+    # maintainers("github_user1", "github_user2")
 
     version("main", branch="main", no_cache=True)
 


### PR DESCRIPTION
Objectives: 
1. Modify the existing package and add xhermes as a dependency, such that the hermes-3 tests all run out-of-the-box when you activate a spack environment with hermes-3 installed.
2. Facilitate development of hermes-3 in a spack environment.

---

Details:
- Adds spack packages for xhermes and those of its Python dependencies that don't already have a published package (all via PyPI).
- Makes xhermes a dependency of hermes-3 if the xhermes variant is selected (on by default).

Other changes (apologies for bundling these all in the same PR):
- Modifies the existing hermes-3 versions such that they git clone boutproject/hermes-3 and its submodules, rather than downloading github tarballs. I couldn't get the latter to build, since, as noted in a comment, git submodules don't get included in the tarballs.
- Adds sundials as an optional spack dependency, controlled via a variant, rather than always downloading it via BOUT.
- Adds version 1.3.1.

--- 
To do:

- [x] Drop py-cython, py-jinja2, py-netcdf4 as direct hermes-3 dependencies?
- [x] Use pypi property for py-xhermes once its published
- [x] Purge # FIXME comments generated by spack 
- [x] Sort out maintainers, license tags for each package