### PR TITLE
Don't compile with gettext, to avoid linking errors

### DIFF
--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -62,6 +62,10 @@ class Hermes3(CMakePackage):
             "HERMES_SLOPE_LIMITER": "limiter",
             "BOUT_USE_PETSC": "petsc",
             "BOUT_USE_SUNDIALS": "sundials",
+            # There are problems with how CMake finds the
+            # glibc/standalone versions of gettext. See
+            # https://github.com/boutproject/hermes-3/issues/356#issuecomment-2999715879
+            "BOUT_USE_NLS": "OFF",
         }
         variants_args = [
             self.define_from_variant(def_str, var_str)

--- a/packages/hermes-3/package.py
+++ b/packages/hermes-3/package.py
@@ -62,10 +62,6 @@ class Hermes3(CMakePackage):
             "HERMES_SLOPE_LIMITER": "limiter",
             "BOUT_USE_PETSC": "petsc",
             "BOUT_USE_SUNDIALS": "sundials",
-            # There are problems with how CMake finds the
-            # glibc/standalone versions of gettext. See
-            # https://github.com/boutproject/hermes-3/issues/356#issuecomment-2999715879
-            "BOUT_USE_NLS": "OFF",
         }
         variants_args = [
             self.define_from_variant(def_str, var_str)
@@ -75,5 +71,9 @@ class Hermes3(CMakePackage):
         # Concatenate different arg types and return
         args = []
         args.extend(variants_args)
+        # There are problems with how CMake finds the
+        # glibc/standalone versions of gettext. See
+        # https://github.com/boutproject/hermes-3/issues/356#issuecomment-2999715879
+        args.append(self.define("BOUT_USE_NLS", False))
 
         return args


### PR DESCRIPTION
Title is self-explanatory. See the discussion in boutproject/hermes-3#356 for why this is necessary.