### PR TITLE
Add NESO-RNG-Toolkit dependency to Hermes-3-VANTAGE

### DIFF
--- a/spack_repo/bout/packages/hermes_3/package.py
+++ b/spack_repo/bout/packages/hermes_3/package.py
@@ -97,6 +97,8 @@ class Hermes3(CMakePackage):
         depends_on("petsc+hdf5+mpi", when="+vantagereactions", type=("build", "link"))
         depends_on("py-h5py", when="+vantagereactions", type=("run"))
         depends_on("py-petsc4py", when="+vantagereactions", type=("run"))
+        depends_on("neso-rng-toolkit", when="+vantagereactions", type=("build", "link"))
+        
 
     def cmake_args(self):
         # Definitions controlled by variants


### PR DESCRIPTION
The toolkit is necessary to sample from distributions for recombination and charge exchange reactions. 