### PR TITLE
Inter-release versions

### DIFF
--- a/spack_repo/bout/packages/hermes_3/package.py
+++ b/spack_repo/bout/packages/hermes_3/package.py
@@ -53,6 +53,8 @@ class Hermes3(CMakePackage):
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
+    #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
+    #  - If the next release version isn't known - increment the last release version by 0.0.1
     # Format:
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("1.4.2rc20260212", commit="1ee1c190742ed36470776d0bcf188aad33754bd0")

--- a/spack_repo/bout/packages/hermes_3/package.py
+++ b/spack_repo/bout/packages/hermes_3/package.py
@@ -43,12 +43,20 @@ class Hermes3(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master", submodules=True, preferred=True)
+    # Release versions
     version("1.4.1", tag="v1.4.1", submodules=True)
     version("1.4.0", tag="v1.4.0", submodules=True)
     version("1.3.1", tag="v1.3.1", submodules=True)
     version("1.3.0", tag="v1.3.0", submodules=True)
     version("1.2.1", tag="v1.2.1", submodules=True)
     version("1.2.0", tag="v1.2.0", submodules=True)
+
+    # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
+    #  - Can be used internally or by consuming packages when inter-release changes break something
+    # Format:
+    #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
+    version("1.4.2rc20260212", commit="1ee1c190742ed36470776d0bcf188aad33754bd0")
+    version("1.4.2rc20260615", commit="c8aa7969ee288862a5af3201db61d932ff64b377")
 
     # Re-define the existing build_type variant to force a default of RelWithDebInfo, rather than Release
     variant(
@@ -92,6 +100,9 @@ class Hermes3(CMakePackage):
 
     # Variant-controlled dependencies
     depends_on("py-xhermes", when="+xhermes", type=("run"))
+    depends_on("py-xhermes@0.1.1:", when="@1.4.2rc20260212: +xhermes")
+    depends_on("py-xhermes@0.1.2rc20260611:", when="@1.4.2rc20260615: +xhermes")
+
     if vantagereactions_pkg_available():
         depends_on("vantagereactions", when="+vantagereactions", type=("build", "link"))
         depends_on("petsc+hdf5+mpi", when="+vantagereactions", type=("build", "link"))

--- a/spack_repo/bout/packages/py_xbout/package.py
+++ b/spack_repo/bout/packages/py_xbout/package.py
@@ -34,6 +34,8 @@ class PyXbout(PythonPackage):
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
+    #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
+    #  - If the next release version isn't known - increment the last release version by 0.0.1
     # Format:
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("0.4.0rc20250925", commit="9c634a4492cd480f9883151b4f89b9d22f607727") # netcdf4=>h5netcdf

--- a/spack_repo/bout/packages/py_xbout/package.py
+++ b/spack_repo/bout/packages/py_xbout/package.py
@@ -23,6 +23,22 @@ class PyXbout(PythonPackage):
         "0.3.7",
         sha256="51b6bcc888553037a623f68dccfe7755ca409801d5b2dd1b8b1ecaca78c1eff1",
     )
+    version(
+        "0.3.8",
+        sha256="9d17f3425b46304d837dff514b3d1541f85e5de69eaa43629c1806220b4a0b26",
+    )
+    version(
+        "0.4.0",
+        sha256="1a118823550e5db0ec239bee2f61a55545eb1643035082e5d4919aa5390cc847")
+
+
+    # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
+    #  - Can be used internally or by consuming packages when inter-release changes break something
+    # Format:
+    #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
+    version("0.4.0rc20250925", commit="9c634a4492cd480f9883151b4f89b9d22f607727") # netcdf4=>h5netcdf
+    version("0.4.0rc20260211", commit="afac4967c662e1c75b549bf585e15a6330548d8c") # h5py
+
 
     # Point at latest master/main branch
     version("master", branch="main")
@@ -37,12 +53,14 @@ class PyXbout(PythonPackage):
 
     # Runtime dependencies
     depends_on("py-animatplot-ng@0.4.2:", type=("build", "run"))
-    depends_on("py-boutdata@0.1.4:", type=("build", "run"))
+    #depends_on("py-boutdata@0.1.4:", type=("build", "run"))
     depends_on("py-dask@2.10.0:+array", type=("build", "run"))
     depends_on("py-gelidum@0.5.3:", type=("build", "run"))
+    depends_on("py-h5py", type=("build", "run"), when="@0.4.0rc20260211:")
+    depends_on("py-h5netcdf", type=("build", "run"), when="@0.4.0rc20250925:")
     depends_on("py-matplotlib@3.3.3:", type=("build", "run"))
     depends_on("py-natsort@5.5.0:", type=("build", "run"))
-    depends_on("py-netcdf4@1.4.0:", type=("build", "run"))
+    depends_on("py-netcdf4@1.4.0:", type=("build", "run"), when="@:0.3.8")
     depends_on("py-pillow@6.1.0:", type=("build", "run"))
     depends_on("py-xarray@2023.01.0:", type=("build", "run"))
 

--- a/spack_repo/bout/packages/py_xhermes/package.py
+++ b/spack_repo/bout/packages/py_xhermes/package.py
@@ -23,6 +23,8 @@ class PyXhermes(PythonPackage):
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
+    #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
+    #  - If the next release version isn't known - increment the last release version by 0.0.1
     # Format:
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("0.1.2rc20260610", commit="cf59f47018a390b847693b426f10365502684984")

--- a/spack_repo/bout/packages/py_xhermes/package.py
+++ b/spack_repo/bout/packages/py_xhermes/package.py
@@ -25,7 +25,8 @@ class PyXhermes(PythonPackage):
     #  - Can be used internally or by consuming packages when inter-release changes break something
     # Format:
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
-    version("0.1.2rc20260611", commit="cf59f47018a390b847693b426f10365502684984")
+    version("0.1.2rc20260610", commit="cf59f47018a390b847693b426f10365502684984")
+    version("0.1.2rc20260611", commit="f29a8be90820afded0e32c00ec971d9d78ca8d4b")
     
 
     # Point at latest master/main branch

--- a/spack_repo/bout/packages/py_xhermes/package.py
+++ b/spack_repo/bout/packages/py_xhermes/package.py
@@ -21,6 +21,13 @@ class PyXhermes(PythonPackage):
         sha256="93440969181f6269955faa8ddb0818589df33e555736eb75fda39fef76092cad",
     )
 
+    # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
+    #  - Can be used internally or by consuming packages when inter-release changes break something
+    # Format:
+    #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
+    version("0.1.2rc20260611", commit="cf59f47018a390b847693b426f10365502684984")
+    
+
     # Point at latest master/main branch
     version("master", branch="main")
 


### PR DESCRIPTION
### Problem
1. Managing hermes dependencies via spack isn't possible using conventional version labels due to infrequent releases
1. xhermes isn't (currently) a hermes submodule, so changes frequently break the spack dev environment
1. Even with xhermes as a git submodule, 1. means that the hermes-3 spack package will only work inside the dev environment
   
### Proposal:
- Whenever a dependency's submodule pointer moves, add a pseudo version in the spack package file pointing to the submodule commit. Reference that version string to set requirements for the hermes package. Use 'rc' suffixes, which spack interprets as release candidates, allowing it to order version strings correctly.

### Example - inter-release updates to xhermes are required by hermes-3

1. In BOUT-spack:
    a. add a new version to of py-xhermes (last release 0.1.1): `version("0.1.2rc20260611", commit="cf59f4...")`
    b. add a new version of hermes-3 (last release 1.4.1), and make it use at least the inter-release xhermes version
    ```
    version("1.4.2rc20260615", commit="c8aa79...")
    
    depends_on("py-xhermes@0.1.2rc20260611:", when="@1.4.2rc20260615: +xhermes")
    ```

2. Update the BOUT-spack submodule in hermes to include the changes.

### Effects and Consequences
- Conventional release labels would continue to work as before
- spack would be able to do semantic versioning properly, using the git-tagged pseudo versions where necessary
- The hermes spack package would work anywhere
- The hermes dev environment would be unaffected (other than fixing the xhermes dependency in the current setup), since develop packages are tagged as spack infinity versions like "master" or "main" $^*$

$^*$ one could engineer an unresolvable conflict by setting a *maximum* version for a dependency of a develop package, but that's already possible with or without this convention.

