### PR TITLE
Remove the re-definitions of the 'build_type' variant in the boutpp and hermes-3 packages

### DIFF
--- a/spack_repo/bout/packages/boutpp/package.py
+++ b/spack_repo/bout/packages/boutpp/package.py
@@ -44,13 +44,6 @@ class Boutpp(CMakePackage):
         default="none",
         multi=True,
     )
-    # Re-define the existing build_type variant to force a default of RelWithDebInfo, rather than Release
-    variant(
-        "build_type",
-        default="RelWithDebInfo",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
     variant("caliper", default=False, description="Builds with Caliper support.")
     variant(
         "check",

--- a/spack_repo/bout/packages/hermes_3/package.py
+++ b/spack_repo/bout/packages/hermes_3/package.py
@@ -60,14 +60,6 @@ class Hermes3(CMakePackage):
     version("1.4.2rc20260212", commit="1ee1c190742ed36470776d0bcf188aad33754bd0")
     version("1.4.2rc20260615", commit="c8aa7969ee288862a5af3201db61d932ff64b377")
 
-    # Re-define the existing build_type variant to force a default of RelWithDebInfo, rather than Release
-    variant(
-        "build_type",
-        default="RelWithDebInfo",
-        description="CMake build type",
-        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
-    )
-
     variant(
         "limiter",
         default="MC",


### PR DESCRIPTION
These overrides were added to make the boutpp package mimic the [BOUT-dev default cmake options](https://github.com/boutproject/BOUT-dev/blob/9eb94c7c9d9539c1e4e60ec84377a48d5ab50b22/cmake/BuildType.cmake#L12).

With hindsight though, it makes more sense to have the packages more optimised by default and just override the build_type in the hermes dev environment instead, to ensure debugging symbols are available.
(N.B. There can be a [non-negligible performance penalty associated with using RelWithDebinfo / -O2](https://github.com/spack/spack/issues/22918).)