### PR TITLE
Package auto updater

### DIFF
--- a/.github/workflows/sync-package-versions-with-hermes-repo.yml
+++ b/.github/workflows/sync-package-versions-with-hermes-repo.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          repository: oparry-ukaea/hermes-3
+          repository: boutproject/hermes-3
           ref: master
           path: ${{ env.HERMES_DIR }}
           sparse-checkout: |

--- a/.github/workflows/sync-package-versions-with-hermes-repo.yml
+++ b/.github/workflows/sync-package-versions-with-hermes-repo.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Clean up temporary files
         run: |
           rm -rf "$HERMES_DIR"
-          jq . "$COMMITS_JSON"
           rm -f "$COMMITS_JSON"
 
       # File the PR

--- a/.github/workflows/sync-package-versions-with-hermes-repo.yml
+++ b/.github/workflows/sync-package-versions-with-hermes-repo.yml
@@ -1,0 +1,74 @@
+---
+name: Update Hermes-3 dependencies
+# Inspects 'ci/requirements.txt' and the BOUT-dev submodule commit in the Hermes-3 repo to
+# check whether new package versions and dependencies need to be added.
+# Files a PR to make the necessary changes.
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-python-test-dependencies:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/boutproject/bout-spack-ci:0.1.0
+    env:
+      HERMES_DIR: .tmp/hermes
+      COMMITS_JSON: .tmp/commits.json
+
+    steps:
+
+      # Checkout BOUT-spack
+      - name: BOUT-spack checkout
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Checkout the Hermes-3 submodules config and the dependencies commits file
+      - name: H3 sparse checkout
+        id: hermes
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: oparry-ukaea/hermes-3
+          ref: master
+          path: ${{ env.HERMES_DIR }}
+          sparse-checkout: |
+            .gitmodules
+            ci/requirements.txt
+          sparse-checkout-cone-mode: false
+
+      # Python script to extract all the commit hashes to json
+      - name: Extract commit hashes
+        run: |
+          . "$SPACK_ROOT/share/spack/setup-env.sh"
+          spack-python ci/extract_commits.py --hermes-dir "$HERMES_DIR" --output "$COMMITS_JSON"
+
+      # Python script to update the Spack packages as necessary
+      - name: Update Spack packages
+        run: |
+          . "$SPACK_ROOT/share/spack/setup-env.sh"
+          spack-python ci/update_spack_packages.py --commits_file "$COMMITS_JSON"
+
+      # Cleanup temporary files
+      - name: Clean up temporary files
+        run: |
+          rm -rf "$HERMES_DIR"
+          jq . "$COMMITS_JSON"
+          rm -f "$COMMITS_JSON"
+
+      # File the PR
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bot/update-package-versions-and-deps
+          commit-message: Update package versions and add dependencies
+          title: Update package versions and add dependencies
+          body: |
+            Add any versions and dependencies implied by submodule pointers and the ci/requirements.txt file in the Hermes-3 repo.
+          delete-branch: true

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM spack/ubuntu-noble:1.2.0
+
+RUN apt update && \
+    apt install -y --no-install-recommends \
+    git \
+    jq \
+    nodejs && \
+    rm -rf /var/lib/apt/lists/*

--- a/ci/extract_commits.py
+++ b/ci/extract_commits.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+
+# Get paths for the hermes directory and the output file from command line args
+parser = argparse.ArgumentParser()
+parser.add_argument("--hermes-dir", required=True)
+parser.add_argument("--output", required=True)
+args = parser.parse_args()
+
+# Read dependency version hashes from requirements.txt
+requirements_path = pathlib.Path(args.hermes_dir) / "ci" / "requirements.txt"
+requirements = requirements_path.read_text()
+commits = {}
+for python_dependency in ["boutdata", "xbout", "xhermes"]:
+    pkg_name = f"py-{python_dependency}"
+    m = re.search(
+        rf"{python_dependency}\s*@\s*git\+https://github\.com/.+?@([0-9a-f]+)",
+        requirements,
+    )
+    if m:
+        commits[pkg_name] = m.group(1)
+
+# Get current Hermes commit and BOUT-dev submodule commit from git directly
+commits["hermes-3"] = subprocess.check_output(
+    ["git", "-C", args.hermes_dir, "rev-parse", "HEAD"],
+    text=True,
+).strip()
+commits["boutpp"] = subprocess.check_output(
+    ["git", "-C", args.hermes_dir, "ls-tree", "HEAD", "external/BOUT-dev"],
+    text=True,
+).split()[2]
+
+# Write commits dict to the output JSON
+with open(args.output, "w") as f:
+    json.dump(commits, f, indent=2)

--- a/ci/push_docker_img.sh
+++ b/ci/push_docker_img.sh
@@ -9,7 +9,7 @@ img_tag="ghcr.io/boutproject/bout-spack-ci:$img_version"
 if ! grep -q '"ghcr.io"' "${HOME}/.docker/config.json" 2>/dev/null; then
     echo "WARNING: You don't appear to be logged in to ghcr.io. Image push might fail."
     echo "Try:"
-    echo "  1. Set GITHUB_PAT to an access token with write:packages scope", then
+    echo "  1. Set GITHUB_PAT to an access token with write:packages scope, then"
     echo "  2. echo \"\$GITHUB_PAT\" | docker login ghcr.io --username <github username> --password-stdin"
     echo
 fi

--- a/ci/push_docker_img.sh
+++ b/ci/push_docker_img.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+img_version="0.1.0"
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+img_tag="ghcr.io/boutproject/bout-spack-ci:$img_version"
+
+# Warn if not logged in to GHCR
+if ! grep -q '"ghcr.io"' "${HOME}/.docker/config.json" 2>/dev/null; then
+    echo "WARNING: You don't appear to be logged in to ghcr.io. Image push might fail."
+    echo "Try:"
+    echo "  1. Set GITHUB_PAT to an access token with write:packages scope", then
+    echo "  2. echo \"\$GITHUB_PAT\" | docker login ghcr.io --username <github username> --password-stdin"
+    echo
+fi
+
+docker build -t "$img_tag" "$this_dir"
+docker push "$img_tag"

--- a/ci/update_spack_packages.py
+++ b/ci/update_spack_packages.py
@@ -1,0 +1,427 @@
+import argparse
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import re
+import spack.paths
+from spack.repo import Repo, PATH
+from spack.version import Version
+from spack.fetch_strategy import GitFetchStrategy
+from spack.version import infinity_versions
+
+# script/global scope storage
+_git_fetcher_cache = {}
+_h3_variant_triggered_dependencies = {"py-xhermes": "xhermes"}
+_repo_ref_cache = {}
+
+
+# ============================== Helper classes ===============================
+@dataclass
+class GitRefMapper:
+    """
+    Bi-directional map between git references (branches/tags) and commit hashes.
+    """
+
+    ref_to_commit: dict[str, str]
+    commit_to_refs: dict[str, list[str]]
+
+    def commit_from_ref(self, ref):
+        return self.ref_to_commit.get(ref, None)
+
+    def refs_from_commit(self, commit):
+        return self.commit_to_refs.get(commit, [])
+
+
+# ==============================================================================
+
+
+# ============================== Helper functions ==============================
+def add_hermes_dependency(h3_content, h3_version, dep_name, dep_version):
+    """
+    Add a new depends_on(...) statement to the hermes-3 package.py file for [dep_name]@[dep_version].
+    """
+
+    # Insert the new depends_on(...) line after the last existing one
+    dep_pattern = re.compile(
+        rf'^\s*depends_on\("{dep_name}".*?\)\s*$',
+        re.MULTILINE,
+    )
+    last_dep_match = None
+    for match in dep_pattern.finditer(h3_content):
+        last_dep_match = match
+
+    # If no dependency exists (as is the case for py-boutdata), it should be skipped
+    if last_dep_match:
+        insert_pos = last_dep_match.end()
+        print(
+            f"Adding new depends_on(...) for [{dep_name}]@[{dep_version}] to hermes-3 package.py"
+        )
+    else:
+        print(
+            f"[{dep_name}] isn't a direct dependency of hermes-3; depends_on(...) line won't be added."
+        )
+        return h3_content
+
+    # Construct the 'depends_on' line
+    # Species that hermes versions [h3_version] and onwards require [dep_name]@[dep_version] or higher
+    dep_variant = _h3_variant_triggered_dependencies.get(dep_name, "")
+    variant_str = f" +{dep_variant}" if dep_variant else ""
+    new_dep_line = f'    depends_on("{dep_name}@{dep_version}:", when="@{h3_version}:{variant_str}")\n'
+    h3_content = h3_content[:insert_pos] + "\n" + new_dep_line + h3_content[insert_pos:]
+    return h3_content
+
+
+def add_package_version(pkg_class, pkg_content, existing_versions, new_version_commit):
+    """
+    Add a new version(...) line to [pkg_content] at commit [new_version_commit].
+    """
+    # Does this commit correspond to a release version?
+    # i.e. Does this commit have a git tag, and is that tag 'version-like'?
+    is_release = False
+    tags = get_git_ref_map(pkg_class).refs_from_commit(new_version_commit)
+    if tags:
+        if len(tags) > 1:
+            print(
+                f"WARNING: Multiple git tags found for commit {new_version_commit}: {tags}. Using the first one."
+            )
+        if is_release_tag(tags[0]):
+            release_tag = tags[0]
+            is_release = True
+
+    # Add either a new release version or a new rc version
+    if is_release:
+        pkg_content, new_version = insert_package_release_version(
+            pkg_content, release_tag
+        )
+    else:
+        pkg_content, new_version = insert_package_rc_version(
+            pkg_content, existing_versions, new_version_commit
+        )
+
+    return pkg_content, new_version
+
+
+# ------------------------------------------------------------------------------
+def extract_version_commits(pkg_name, pkg_class):
+    """
+    Extract a dict of commit_hash-> {"version": version_str, "type": version_type} from the package class.
+      version_type is one of "commit", "branch", "tag".
+    """
+    version_commits = {}
+    for version, metadata in pkg_class.versions.items():
+        # Skip spack "infinity" versions
+        if str(version) in infinity_versions:
+            continue
+
+        commit = None
+        vtype = "unknown"
+        if "commit" in metadata:
+            commit = metadata["commit"]
+            vtype = "commit"
+        else:
+            for tag in ["branch", "tag"]:
+                if tag in metadata:
+                    # Try the reference first, then the version string, then "v" + version string
+                    candidate_refs = [
+                        metadata[tag],
+                        str(version),
+                        f"v{str(version)}",
+                    ]
+                    for ref in candidate_refs:
+                        commit = get_git_ref_map(pkg_class).commit_from_ref(ref)
+                        if commit is not None:
+                            break
+                if commit is not None:
+                    vtype = tag
+                    break
+
+        if commit is None:
+            print(
+                f"WARNING: Unable to determine commit for {pkg_name}@{version}. Skipping."
+            )
+        else:
+            version_commits[commit] = {"version": version.__str__(), "type": vtype}
+    return version_commits
+
+
+# ------------------------------------------------------------------------------
+def get_git_ref_map(pkg_class):
+    """
+    Generate/retrieve a GitRefMapper for the [pkg_class], preferring a cached version if one exists.
+    """
+
+    # Return cached-refs if they already exist
+    if pkg_class.git in _repo_ref_cache:
+        return _repo_ref_cache[pkg_class.git]
+
+    # Create a spack git-fetcher / retrieve cached version for the relevant repo
+    if pkg_class.git not in _git_fetcher_cache:
+        _git_fetcher_cache[pkg_class.git] = GitFetchStrategy(git=pkg_class.git)
+    fetcher = _git_fetcher_cache[pkg_class.git]
+
+    # Use spack machinery to bare-clone the repo into a cache directory
+    cache_dir = (
+        Path(spack.paths.user_repos_cache_path)
+        / f"ci-version-cache-{abs(hash(pkg_class.git))}"
+    )
+    if not cache_dir.exists():
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        fetcher.bare_clone(str(cache_dir))
+
+    with working_directory(cache_dir):
+        output = fetcher.git(
+            "show-ref",
+            "--tags",
+            "--heads",
+            output=str,
+        )
+
+    ref_to_commit = {}
+    commit_to_refs = defaultdict(list)
+
+    for line in output.splitlines():
+        commit, ref = line.split()
+
+        short_ref = ref.removeprefix("refs/tags/")
+        short_ref = short_ref.removeprefix("refs/heads/")
+
+        ref_to_commit[short_ref] = commit
+        commit_to_refs[commit].append(short_ref)
+
+    # Create the two-way mapper
+    result = GitRefMapper(
+        ref_to_commit=dict(ref_to_commit),
+        commit_to_refs=dict(commit_to_refs),
+    )
+
+    # Cache the mapper
+    _repo_ref_cache[pkg_class.git] = result
+
+    return result
+
+
+# ------------------------------------------------------------------------------
+def get_pkg_classes(pkg_names, namespace="bout"):
+    """
+    Read classes from the package repo.
+    """
+    repo_path = Path(__file__).resolve().parent.parent / "spack_repo" / namespace
+    local_repo = Repo(
+        str(repo_path),
+        cache=PATH.repos[0]._cache,
+    )
+    return {pkg_name: local_repo.get_pkg_class(pkg_name) for pkg_name in pkg_names}
+
+
+# ------------------------------------------------------------------------------
+def get_rc_version_tag(existing_versions):
+    """
+    Given a dict of existing versions, return the next rc version tag.
+    """
+    # Get major, minor, patch for the latest released version
+    released_versions = [
+        m["version"]
+        for m in existing_versions.values()
+        if m["type"] in ["sha256", "tag"]
+    ]
+
+    latest_released_version = max(released_versions, key=Version)
+    major, minor, patch = map(int, latest_released_version.split("."))
+
+    # rc version is current version with patch incremented + "rcYYYYMMDD" suffix
+    date_str = datetime.now().strftime("%Y%m%d")
+
+    return f"{major}.{minor}.{patch + 1}rc{date_str}"
+
+
+# ------------------------------------------------------------------------------
+def insert_package_rc_version(pkg_content, existing_versions, new_version_commit):
+    """
+    Add a new RC version(...) line to package.py.
+    """
+
+    new_version = get_rc_version_tag(existing_versions)
+
+    version_line = f'    version("{new_version}", commit="{new_version_commit}")'
+
+    # This should never be true, but just in case...
+    if new_version_commit in pkg_content:
+        return pkg_content
+
+    # Look for existing RC versions
+    rc_pattern = re.compile(
+        r'^\s*version\("\d+\.\d+\.\d+rc\d{8}".*?\)\s*$',
+        re.MULTILINE,
+    )
+    matches = list(rc_pattern.finditer(pkg_content))
+
+    if matches:
+        # If there are existing RC versions, insert after the last one
+        last = matches[-1]
+        insert_pos = last.end()
+    else:
+        # Otherwise, insert on the first new line after the standardised RC version comment
+        marker = "next_release_version"
+        preamble_end_pos = pkg_content.find(marker)
+
+        if preamble_end_pos < 0:
+            raise RuntimeError("Could not find RC version preamble comment")
+
+        insert_pos = pkg_content.find("\n", preamble_end_pos) + 1
+
+    return pkg_content[:insert_pos] + version_line + "\n" + pkg_content[
+        insert_pos:
+    ], new_version
+
+
+# ------------------------------------------------------------------------------
+def insert_package_release_version(pkg_content, tag):
+    """
+    Insert a new release version into tagged_versions = [...]
+    """
+
+    release_version = tag.removeprefix("v")
+
+    # Locate tagged_versions list
+    pattern = re.compile(
+        r"(tagged_versions\s*=\s*\[)(.*?)(\])",
+        re.DOTALL,
+    )
+    match = pattern.search(pkg_content)
+    if not match:
+        raise RuntimeError("Could not find tagged_versions block")
+    list_body = match.group(2)
+
+    # Extract existing versions
+    versions = re.findall(r'"([^"]+)"', list_body)
+
+    if release_version in versions:
+        return pkg_content
+
+    versions.append(release_version)
+    versions.sort(key=Version)
+
+    new_body = "".join(f'\n        "{v}",' for v in versions)
+    replacement = f"{match.group(1)}{new_body}\n    {match.group(3)}"
+
+    return pkg_content[: match.start()] + replacement + pkg_content[
+        match.end() :
+    ], release_version
+
+
+# ------------------------------------------------------------------------------
+def is_release_tag(tag):
+    """
+    Check if a git tag has the form of a release version (vX.Y.Z or X.Y.Z, where X, Y, and Z are integers).
+    """
+    pattern = r"^v?\d+\.\d+\.\d+$"
+    return re.match(pattern, tag) is not None
+
+
+# ------------------------------------------------------------------------------
+def read_pkg_files(pkg_classes):
+    """
+    Read package.py for each package in the <pkg_classes> dict and return the contents in another dict.
+    """
+    pkgs_content = {}
+    for pkg_name, pkg_class in pkg_classes.items():
+        pkgfile = Path(pkg_class.package_dir) / "package.py"
+        if not pkgfile.exists():
+            print(
+                f"WARNING: Package file for {pkg_name} not found at [{pkgfile}]!? Skipping."
+            )
+            continue
+        pkgs_content[pkg_name] = pkgfile.read_text()
+    return pkgs_content
+
+
+# ------------------------------------------------------------------------------
+@contextmanager
+def working_directory(path):
+    old_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
+
+
+# =============================================================================
+def main():
+
+    # Read commits json
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commits_file", required=True)
+    args = parser.parse_args()
+
+    with open(args.commits_file) as f:
+        commits = json.load(f)
+
+    # Get all the package classes
+    pkg_classes = get_pkg_classes(commits.keys())
+
+    # Read all the package files
+    all_content = read_pkg_files(pkg_classes)
+
+    # Extract versions
+    all_version_commits = {
+        pkg_name: extract_version_commits(pkg_name, pkg_class)
+        for pkg_name, pkg_class in pkg_classes.items()
+    }
+
+    # Separate the hermes commit; everything else is a dependency
+    hermes_commit = commits.pop("hermes-3")
+
+    # Add any new versions of dependencies to their respective package.py files
+    new_dependency_versions = {}
+    for dep_name, commit in commits.items():
+        pkg_version_commits = all_version_commits.get(dep_name, {})
+        if commit in pkg_version_commits:
+            print(
+                f"Commit [{commit}] of [{dep_name}] already registered as version [{pkg_version_commits[commit]['version']}]."
+            )
+        else:
+            all_content[dep_name], dep_version = add_package_version(
+                pkg_classes[dep_name],
+                all_content[dep_name],
+                pkg_version_commits,
+                commit,
+            )
+            print(
+                f"ADDED commit [{commit}] as version [{dep_version}] of [{dep_name}]."
+            )
+            new_dependency_versions[dep_name] = dep_version
+
+    # Add depends_on(...) statements to the hermes package file if necessary
+    if new_dependency_versions:
+        existing_hermes_versions = extract_version_commits(
+            "hermes-3", pkg_classes["hermes-3"]
+        )
+        # If there are new dependencies, we need a new hermes version at the current commit
+        print(f"Adding new hermes-3 version at commit [{hermes_commit}]")
+        all_content["hermes-3"], new_hermes_version = add_package_version(
+            pkg_classes["hermes-3"],
+            all_content["hermes-3"],
+            existing_hermes_versions,
+            hermes_commit,
+        )
+
+        for dep_name, dep_version in new_dependency_versions.items():
+            all_content["hermes-3"] = add_hermes_dependency(
+                all_content["hermes-3"], new_hermes_version, dep_name, dep_version
+            )
+
+    # Write out all the modified package.py files
+    for dep_name, content in all_content.items():
+        pkgfile = Path(pkg_classes[dep_name].package_dir) / "package.py"
+        pkgfile.write_text(content)
+
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()

--- a/ci/update_spack_packages.py
+++ b/ci/update_spack_packages.py
@@ -313,12 +313,12 @@ def insert_package_release_version(pkg_content, tag):
 
     # Locate tagged_versions list
     pattern = re.compile(
-        r"(tagged_versions\s*=\s*\[)(.*?)(\])",
-        re.DOTALL,
+        r"(^[ \t]*tagged_versions[ \t]*=[ \t]*\[)(.*?)(^[ \t]*\])",
+        re.MULTILINE | re.DOTALL,
     )
     match = pattern.search(pkg_content)
     if not match:
-        raise RuntimeError("Could not find tagged_versions block")
+        raise RuntimeError("Could not find tagged_versions list")
     list_body = match.group(2)
 
     # Extract existing versions

--- a/ci/update_spack_packages.py
+++ b/ci/update_spack_packages.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -54,7 +55,7 @@ def add_hermes_dependency(h3_content, h3_version, dep_name, dep_version):
     for match in dep_pattern.finditer(h3_content):
         last_dep_match = match
 
-    # If no dependency exists (as is the case for py-boutdata), it should be skipped
+    # If no dependency exists (as is the case for py-xbout), it should be skipped
     if last_dep_match:
         insert_pos = last_dep_match.end()
         print(
@@ -67,7 +68,7 @@ def add_hermes_dependency(h3_content, h3_version, dep_name, dep_version):
         return h3_content
 
     # Construct the 'depends_on' line
-    # Species that hermes versions [h3_version] and onwards require [dep_name]@[dep_version] or higher
+    # Specifies that hermes versions [h3_version] and onwards require [dep_name]@[dep_version] or higher
     dep_variant = _h3_variant_triggered_dependencies.get(dep_name, "")
     variant_str = f" +{dep_variant}" if dep_variant else ""
     new_dep_line = f'    depends_on("{dep_name}@{dep_version}:", when="@{h3_version}:{variant_str}")\n'
@@ -84,12 +85,10 @@ def add_package_version(pkg_class, pkg_content, existing_versions, new_version_c
     is_release = False
     tags = get_git_ref_map(pkg_class).refs_from_commit(new_version_commit)
     if tags:
-        if len(tags) > 1:
-            print(
-                f"WARNING: Multiple git tags found for commit {new_version_commit}: {tags}. Using the first one."
-            )
-        if is_release_tag(tags[0]):
-            release_tag = tags[0]
+        release_tags = [t for t in tags if is_release_tag(t)]
+        if release_tags:
+            # Prefer the highest semantic version if multiple tags exist
+            release_tag = max(release_tags, key=lambda t: Version(t.removeprefix("v")))
             is_release = True
 
     # Add either a new release version or a new rc version
@@ -164,14 +163,11 @@ def get_git_ref_map(pkg_class):
     fetcher = _git_fetcher_cache[pkg_class.git]
 
     # Use spack machinery to bare-clone the repo into a cache directory
-    cache_dir = (
-        Path(spack.paths.user_repos_cache_path)
-        / f"ci-version-cache-{abs(hash(pkg_class.git))}"
-    )
+    repo_id = hashlib.sha1(pkg_class.git.encode("utf-8")).hexdigest()[:12]
+    cache_dir = Path(spack.paths.user_repos_cache_path) / f"ci-version-cache-{repo_id}"
     if not cache_dir.exists():
         cache_dir.parent.mkdir(parents=True, exist_ok=True)
         fetcher.bare_clone(str(cache_dir))
-
     with working_directory(cache_dir):
         output = fetcher.git(
             "show-ref",
@@ -180,17 +176,34 @@ def get_git_ref_map(pkg_class):
             output=str,
         )
 
+    # Parse the output of `git show-ref`
     ref_to_commit = {}
-    commit_to_refs = defaultdict(list)
+    tag_refs = {}
+    peeled_tag_refs = {}
 
+    # Put heads straight in to the forward map (ref->commit) but discriminate between tags and 'peeled' tags
     for line in output.splitlines():
         commit, ref = line.split()
 
-        short_ref = ref.removeprefix("refs/tags/")
-        short_ref = short_ref.removeprefix("refs/heads/")
+        if ref.startswith("refs/heads/"):
+            ref_to_commit[ref.removeprefix("refs/heads/")] = commit
+        elif ref.startswith("refs/tags/"):
+            short_ref = ref.removeprefix("refs/tags/")
+            if short_ref.endswith("^{}"):
+                peeled_tag_refs[short_ref.removesuffix("^{}")] = commit
+            else:
+                tag_refs[short_ref] = commit
 
-        ref_to_commit[short_ref] = commit
-        commit_to_refs[commit].append(short_ref)
+    # Add tag refs to the forward map, preferring peeled tags where they exist
+    for tag_name, commit in tag_refs.items():
+        ref_to_commit[tag_name] = peeled_tag_refs.get(tag_name, commit)
+    for tag_name, commit in peeled_tag_refs.items():
+        ref_to_commit[tag_name] = commit
+
+    # Create the reverse map
+    commit_to_refs = defaultdict(list)
+    for ref_name, commit in ref_to_commit.items():
+        commit_to_refs[commit].append(ref_name)
 
     # Create the two-way mapper
     result = GitRefMapper(
@@ -222,15 +235,18 @@ def get_rc_version_tag(existing_versions):
     """
     Given a dict of existing versions, return the next rc version tag.
     """
-    # Get major, minor, patch for the latest released version
-    released_versions = [
-        m["version"]
-        for m in existing_versions.values()
-        if m["type"] in ["sha256", "tag"]
+    # Get major, minor, patch for the latest tagged release version
+    tagged_release_versions = [
+        commit_map["version"]
+        for commit_map in existing_versions.values()
+        if commit_map["type"] == "tag"
     ]
-
-    latest_released_version = max(released_versions, key=Version)
-    major, minor, patch = map(int, latest_released_version.split("."))
+    if not tagged_release_versions:
+        raise RuntimeError(
+            "No released (tag/sha256) versions found; cannot derive next rc version."
+        )
+    latest_tagged_release_version = max(tagged_release_versions, key=Version)
+    major, minor, patch = map(int, latest_tagged_release_version.split("."))
 
     # rc version is current version with patch incremented + "rcYYYYMMDD" suffix
     date_str = datetime.now().strftime("%Y%m%d")
@@ -250,19 +266,21 @@ def insert_package_rc_version(pkg_content, existing_versions, new_version_commit
 
     # This should never be true, but just in case...
     if new_version_commit in pkg_content:
-        return pkg_content
+        return pkg_content, new_version
 
-    # Look for existing RC versions
+    # Match RC version lines without consuming the newline after them.
+    # Allow trailing comments
     rc_pattern = re.compile(
-        r'^\s*version\("\d+\.\d+\.\d+rc\d{8}".*?\)\s*$',
+        r'^[ \t]*version\("\d+\.\d+\.\d+rc\d{8}".*?\)\s*(?:#.*)?$',
         re.MULTILINE,
     )
     matches = list(rc_pattern.finditer(pkg_content))
 
     if matches:
-        # If there are existing RC versions, insert after the last one
+        # Insert after the matched line break so the new version always lands on its own line.
         last = matches[-1]
-        insert_pos = last.end()
+        line_end = pkg_content.find("\n", last.end())
+        insert_pos = line_end + 1 if line_end >= 0 else len(pkg_content)
     else:
         # Otherwise, insert on the first new line after the standardised RC version comment
         marker = "next_release_version"
@@ -273,7 +291,14 @@ def insert_package_rc_version(pkg_content, existing_versions, new_version_commit
 
         insert_pos = pkg_content.find("\n", preamble_end_pos) + 1
 
-    return pkg_content[:insert_pos] + version_line + "\n" + pkg_content[
+    # Edge case where the new line is being inserted at EOF and the file has no trailing newline
+    line_prefix = (
+        "\n"
+        if insert_pos == len(pkg_content) and not pkg_content.endswith("\n")
+        else ""
+    )
+
+    return pkg_content[:insert_pos] + line_prefix + version_line + "\n" + pkg_content[
         insert_pos:
     ], new_version
 
@@ -300,7 +325,7 @@ def insert_package_release_version(pkg_content, tag):
     versions = re.findall(r'"([^"]+)"', list_body)
 
     if release_version in versions:
-        return pkg_content
+        return pkg_content, release_version
 
     versions.append(release_version)
     versions.sort(key=Version)

--- a/spack_repo/bout/packages/boutpp/package.py
+++ b/spack_repo/bout/packages/boutpp/package.py
@@ -28,6 +28,13 @@ class Boutpp(CMakePackage):
     for v in tagged_versions:
         version(v, tag=f"v{v}", submodules=True)
 
+    # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
+    #  - Can be used internally or by consuming packages when inter-release changes break something
+    #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
+    #  - If the next release version isn't known - increment the last release version by 0.0.1
+    # Format (don't change the line below, as it is used in CI to update package versions!)
+    #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
+
     # Patches
     patch("fix_thirdparty_cmake_v5.0.0.patch", when="@5.0.0")
     patch("fix_thirdparty_cmake_v5.1.x.patch", when="@5.1")

--- a/spack_repo/bout/packages/hermes_3/package.py
+++ b/spack_repo/bout/packages/hermes_3/package.py
@@ -43,19 +43,17 @@ class Hermes3(CMakePackage):
 
     version("develop", branch="develop")
     version("master", branch="master", submodules=True, preferred=True)
+
     # Release versions
-    version("1.4.1", tag="v1.4.1", submodules=True)
-    version("1.4.0", tag="v1.4.0", submodules=True)
-    version("1.3.1", tag="v1.3.1", submodules=True)
-    version("1.3.0", tag="v1.3.0", submodules=True)
-    version("1.2.1", tag="v1.2.1", submodules=True)
-    version("1.2.0", tag="v1.2.0", submodules=True)
+    tagged_versions = ["1.2.0", "1.2.1", "1.3.0", "1.3.1", "1.4.0", "1.4.1"]
+    for v in tagged_versions:
+        version(v, tag=f"v{v}", submodules=True)
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
     #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
     #  - If the next release version isn't known - increment the last release version by 0.0.1
-    # Format:
+    # Format (don't change the line below, as it is used in CI to update package versions!)
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("1.4.2rc20260212", commit="1ee1c190742ed36470776d0bcf188aad33754bd0")
     version("1.4.2rc20260615", commit="c8aa7969ee288862a5af3201db61d932ff64b377")

--- a/spack_repo/bout/packages/py_boutdata/package.py
+++ b/spack_repo/bout/packages/py_boutdata/package.py
@@ -6,21 +6,35 @@ class PyBoutdata(PythonPackage):
     """Python tools for working with BOUT++."""
 
     homepage = "https://github.com/boutproject/boutdata"
-    pypi = "boutdata/boutdata-0.2.1.tar.gz"
+    git = "https://github.com/boutproject/boutdata.git"
 
     # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
     license("LGPL-3.0")
 
-    version(
-        "0.3.0",
-        sha256="d76dd6fc1f5d916006a5e5d6db9b2835f5b5eb94c675169fd2529fc36c820323"
-    )
-    version(
+    # Release version git tags
+    tagged_versions = [
+        "0.1.5",
+        "0.1.6",
+        "0.1.7",
+        "0.1.8",
+        "0.1.9",
+        "0.1.10",
+        "0.2.0",
         "0.2.1",
-        sha256="043cddaeb38b128d2525f2005f48a5b7717ff5832a932183a4bef1d3eae389e0",
-    )
+        "0.3.0",
+        "0.4.0",
+    ]
+    for v in tagged_versions:
+        version(v, tag=f"v{v}")
+
+    # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
+    #  - Can be used internally or by consuming packages when inter-release changes break something
+    #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
+    #  - If the next release version isn't known - increment the last release version by 0.0.1
+    # Format (don't change the line below, as it is used in CI to update package versions!)
+    #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
 
     # Compatible Python versions
     depends_on("python@3.9:", type=("build", "run"))

--- a/spack_repo/bout/packages/py_xbout/package.py
+++ b/spack_repo/bout/packages/py_xbout/package.py
@@ -18,8 +18,8 @@ class PyXbout(PythonPackage):
 
     # license("Apache-2.0")
 
-    # Release version git tags
-    tagged_versions = [
+    # Older versions had tags "x.y.z" rather than "vx.y.z"
+    oldstyle_tagged_versions = [
         "0.3.0",
         "0.3.1",
         "0.3.2",
@@ -27,6 +27,12 @@ class PyXbout(PythonPackage):
         "0.3.4",
         "0.3.5",
         "0.3.6",
+    ]
+    for v in oldstyle_tagged_versions:
+        version(v, tag=v)
+
+    # Standard "vx.y.z" tagged versions
+    tagged_versions = [
         "0.3.7",
         "0.3.8",
         "0.4.0",

--- a/spack_repo/bout/packages/py_xbout/package.py
+++ b/spack_repo/bout/packages/py_xbout/package.py
@@ -46,7 +46,7 @@ class PyXbout(PythonPackage):
 
 
     # Point at latest master/main branch
-    version("master", branch="main")
+    version("master", branch="master")
 
     # Compatible Python versions
     depends_on("python@3.9:", type=("build", "run"))

--- a/spack_repo/bout/packages/py_xbout/package.py
+++ b/spack_repo/bout/packages/py_xbout/package.py
@@ -11,32 +11,35 @@ class PyXbout(PythonPackage):
     """xBOUT provides an interface for collecting the output data from a BOUT++ simulation into an xarray dataset in an efficient and scalable way, as well as accessor methods for common BOUT++ analysis and plotting tasks."""
 
     homepage = "https://github.com/boutproject/xBOUT"
-    pypi = "xbout/xbout-0.3.7.tar.gz"
-    git      = "https://github.com/boutproject/xbout.git"
+    git = "https://github.com/boutproject/xbout.git"
 
     # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    #license("Apache-2.0")
+    # license("Apache-2.0")
 
-    version(
+    # Release version git tags
+    tagged_versions = [
+        "0.3.0",
+        "0.3.1",
+        "0.3.2",
+        "0.3.3",
+        "0.3.4",
+        "0.3.5",
+        "0.3.6",
         "0.3.7",
-        sha256="51b6bcc888553037a623f68dccfe7755ca409801d5b2dd1b8b1ecaca78c1eff1",
-    )
-    version(
         "0.3.8",
-        sha256="9d17f3425b46304d837dff514b3d1541f85e5de69eaa43629c1806220b4a0b26",
-    )
-    version(
         "0.4.0",
-        sha256="1a118823550e5db0ec239bee2f61a55545eb1643035082e5d4919aa5390cc847")
+    ]
 
+    for v in tagged_versions:
+        version(v, tag=f"v{v}")
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
     #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
     #  - If the next release version isn't known - increment the last release version by 0.0.1
-    # Format:
+    # Format (don't change the line below, as it is used in CI to update package versions!)
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("0.4.0rc20250925", commit="9c634a4492cd480f9883151b4f89b9d22f607727") # netcdf4=>h5netcdf
     version("0.4.0rc20260211", commit="afac4967c662e1c75b549bf585e15a6330548d8c") # h5py

--- a/spack_repo/bout/packages/py_xhermes/package.py
+++ b/spack_repo/bout/packages/py_xhermes/package.py
@@ -5,35 +5,28 @@ class PyXhermes(PythonPackage):
     """xHermes is a post-processing package for Hermes-3 in 1D, 2D and 3D which provides automatic conversion to SI units and many useful plotting routines."""
 
     homepage = "https://github.com/boutproject/xhermes"
-    pypi = "xhermes/xhermes-0.1.0.tar.gz"
-    git      = "https://github.com/boutproject/xhermes.git"
+    git = "https://github.com/boutproject/xhermes.git"
 
     # Set a maintainer if submitting this package to the spack repo
     # maintainers("github_user1", "github_user2")
 
-    # PyPI versions with checksums
-    version(
+    # Release version git tags
+    tagged_versions = [
         "0.1.0",
-        sha256="3aa0ba60d06cd18adfc46132f1d8deb3cd4ce69e67ee210d491bdfd7ba7871a7",
-    )
-    version(
         "0.1.1",
-        sha256="93440969181f6269955faa8ddb0818589df33e555736eb75fda39fef76092cad",
-    )
-    version(
         "0.2.0",
-        sha256="ad100be47af3570f2a9bffea3efcb50b4b304bdfe7700cc0453151ab3cd2148e",
-    )
+    ]
+    for v in tagged_versions:
+        version(v, tag=f"v{v}")
 
     # Treat intermediate versions, mapped to specific Git commits, as release candidates ('rc' suffixes)
     #  - Can be used internally or by consuming packages when inter-release changes break something
     #  - By convention, commit hashes point to master; i.e. the commit where the breaking change was merged in
     #  - If the next release version isn't known - increment the last release version by 0.0.1
-    # Format:
+    # Format (don't change the line below, as it is used in CI to update package versions!)
     #   version("<next_release_version>rc<date_in_YYYYMMDD>", commit="<git_hash>")
     version("0.1.2rc20260610", commit="cf59f47018a390b847693b426f10365502684984")
     version("0.1.2rc20260611", commit="f29a8be90820afded0e32c00ec971d9d78ca8d4b")
-    
 
     # Point at latest master/main branch
     version("master", branch="main")


### PR DESCRIPTION
A github action that attempts to auto-update package files based on
1. The commits listed in <hermes-3_repo>/ci/requirements.txt and
2. The BOUT-dev commit in <hermes-3_repo>/.gitmodules

The basic idea is (in a container with spack, git and nodejs installed):
  1. Checkout BOUT-spack
  2. Checkout the two Hermes-3 files
  3. Run a python script to extract the commits from those files and write them to json
  4. Run a second python script that determines whether the commits correspond to new versions, adds them to the relevant package files if they do, and updates the dependencies in the hermes-3 package if new dependency versions are added.
  5. File a BOUT-spack PR to make the package updates.
 
 